### PR TITLE
fix(websock-tests): adds delay between connecting and message publishing

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(promises);
+      await delay(5000);
       // All connected and relay ready
 
       const contentTopic = `/waku-tests/1/relay-test-${id}/utf8`;
@@ -139,6 +140,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(promises);
+      await delay(5000);
       // All connected and relay ready
 
       const contentTopic = `/waku-tests/1/light-push-${id}/utf8`;
@@ -212,6 +214,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(promises);
+      await delay(5000);
       // All connected and relay ready
 
       const hostnames = nodes.map((a) => {

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(relayPromises);
-      await delay(30000);
+      await delay(5000);
 
       console.log(messages);
 
@@ -174,7 +174,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(relayPromises);
-      await delay(30000);
+      await delay(5000);
 
       console.log(messages);
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(relayPromises);
-      await delay(5000);
+      await delay(30000);
 
       console.log(messages);
 
@@ -174,7 +174,7 @@ export default function runAll(nodes) {
       });
 
       await Promise.all(relayPromises);
-      await delay(5000);
+      await delay(30000);
 
       console.log(messages);
 


### PR DESCRIPTION
Closes https://github.com/status-im/nwaku/issues/949

This PR fixes inconsistent and failing websocket tests, by adding enough of a delay between the connection-phase and the message publishing-phase of each test for the libp2p pubsub reading loop to be established. Previously some tests would fail when the first test message(s) were published while the connections were not yet fully established.